### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/unit-tests-python.yaml
+++ b/.github/workflows/unit-tests-python.yaml
@@ -3,7 +3,12 @@ name: Unit tests
 on:
   pull_request:
   workflow_call:
-
+    inputs:
+      PYTHON_VERSION:
+        description: 'Python version, eg 3.11'
+        default: '3.11'
+        type: string
+    
 jobs:
   unit-testing:
     runs-on: ubuntu-latest
@@ -15,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ inputs.PYTHON_VERSION }}
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt

--- a/.pre-commit-config-python.yaml
+++ b/.pre-commit-config-python.yaml
@@ -1,30 +1,30 @@
 repos:
-  -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.3.0
-      hooks:
-      -   id: check-yaml
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
       # Disabled so that we're not initially modifying files
       #-   id: end-of-file-fixer
       #-   id: trailing-whitespace
-      -   id: check-merge-conflict
-      -   id: detect-private-key
+      - id: check-merge-conflict
+      - id: detect-private-key
 
-  -   repo: https://github.com/pycqa/isort
-      rev: 5.13.2
-      hooks:
-        - id: isort
-          name: isort python
-          args: [ --check, --diff, --profile, black ]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort python
+        args: [--check, --diff, --profile, black]
 
-  -   repo: https://github.com/psf/black
-      rev: 22.10.0
-      hooks:
-      -   id: black
-          args: [ --check ]
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: [--check]
 
-  -   repo: https://github.com/abravalheri/validate-pyproject
-      rev: v0.18
-      hooks:
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.18
+    hooks:
       - id: validate-pyproject
         # Optional extra validations from SchemaStore:
         additional_dependencies: ["validate-pyproject-schema-store[all]"]
@@ -35,4 +35,4 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: [ --ignore, I001 ]
+        args: [--ignore, I001]


### PR DESCRIPTION
This allows the use of Python 3.12 with this repo. This requires upgrading Black and allowing the Python version to be specified in the unit test action.