### PR TITLE
fix: replace broken bandit-action with direct installation

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         if: ${{ inputs.ENABLE_BANDIT }}
         with:
           python-version: "3.x"


### PR DESCRIPTION
mdegis/bandit-action@v1.0.1 fails with missing pbr dependency. Replace with direct pip installation and CLI execution while maintaining the same security configuration.

This was found while reviewing https://github.com/EO-DataHub/harvest-transformer/pull/54