### PR TITLE
Use docker metadata-action to get tags and labels

### DIFF
--- a/.github/workflows/ecr-publish.yaml
+++ b/.github/workflows/ecr-publish.yaml
@@ -8,9 +8,10 @@ on:
         required: true
         type: string
       IMAGE_TAG:
-        description: Tag name
-        required: true
+        description: "[DEPRECATED: tags are now auto-generated] Tag name"
+        required: false
         type: string
+        default: ''
       AWS_ROLE_ARN:
         description: AWS role ARN e.g. arn:aws:iam::1234567890:role/role-name
         required: true
@@ -37,7 +38,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Check tag
-        run: echo ${{ inputs.IMAGE_TAG }}
+        if: inputs.IMAGE_TAG != ''
+        run: echo "::warning::IMAGE_TAG input is deprecated and ignored. Tags are now auto-generated."
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
@@ -57,6 +59,20 @@ jobs:
       - name: Check ECR registry
         run: echo ${{ steps.login-ecr-public.outputs.registry }}/${{ inputs.AWS_ECR_ALIAS }}
 
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.login-ecr-public.outputs.registry }}/${{ inputs.AWS_ECR_ALIAS }}/${{ inputs.IMAGE_NAME }}
+          tags: |
+            # main branch -> "latest"
+            type=raw,value=latest,enable=${{ github.ref_name == 'main' }}
+            # versioned tags (v1.0.0) -> "1.0.0" (strip v prefix)
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # other refs -> ref name as-is
+            type=ref,event=branch,enable=${{ github.ref_name != 'main' && !startsWith(github.ref, 'refs/tags/') }}
+            type=ref,event=tag,enable=${{ startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v') }}
+
         # This will cache Docker layers.
         # We could also cache the cache mounts used in the Dockerfile but do not,
         # see https://docs.docker.com/build/ci/github-actions/cache/
@@ -65,7 +81,8 @@ jobs:
         with:
           context: ${{ inputs.BUILD_CONTEXT }}
           push: true
-          tags: ${{ steps.login-ecr-public.outputs.registry }}/${{ inputs.AWS_ECR_ALIAS }}/${{ inputs.IMAGE_NAME }}:${{ inputs.IMAGE_TAG }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_REF_NAME=${{ github.ref_name }}
             GIT_SHA=${{ github.sha }}


### PR DESCRIPTION
This will make CI/CD setup easier, removing the need of [get-version-tag.yaml](https://github.com/EO-DataHub/github-actions/blob/main/.github/workflows/get-version-tag.yaml). Also adds additional Docker metadata labels.