### PR TITLE
Support passing build arguments

### DIFF
--- a/.github/workflows/ecr-publish.yaml
+++ b/.github/workflows/ecr-publish.yaml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         default: '.'
+      BUILD_ARGS:
+        description: Optional Docker build args (multiline KEY=VALUE, one per line)
+        required: false
+        type: string
+        default: ''
 
 jobs:
   docker:
@@ -90,5 +95,6 @@ jobs:
           build-args: |
             GIT_REF_NAME=${{ github.ref_name }}
             GIT_SHA=${{ github.sha }}
+            ${{ inputs.BUILD_ARGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds ability to pass build arguments.
Required by this PR https://github.com/EO-DataHub/eodh-jupyter-images/pull/8


```yaml
  publish:
    needs: prepare
    uses: EO-DataHub/github-actions/.github/workflows/ecr-publish.yaml@main
    with:
      IMAGE_NAME: eodh-default-notebook
      IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
      AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
      AWS_ECR_ALIAS: ${{ vars.AWS_ECR_ALIAS }}
      BUILD_CONTEXT: notebook
      BUILD_ARGS: |
        PYTHON_VERSION=3.13
```