### PR TITLE
Allow IMAGE_TAG input override

### DIFF
--- a/.github/workflows/ecr-publish.yaml
+++ b/.github/workflows/ecr-publish.yaml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       IMAGE_TAG:
-        description: "[DEPRECATED: tags are now auto-generated] Tag name"
+        description: "Optional tag override. When provided, used as the sole Docker image tag. When omitted, tags are auto-generated from git refs."
         required: false
         type: string
         default: ''
@@ -31,9 +31,20 @@ on:
         type: string
         default: ''
 
+    outputs:
+      tags:
+        description: Generated Docker image tags
+        value: ${{ jobs.docker.outputs.tags }}
+      labels:
+        description: Generated Docker image labels
+        value: ${{ jobs.docker.outputs.labels }}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta-auto.outputs.tags || steps.meta-override.outputs.tags }}
+      labels: ${{ steps.meta-auto.outputs.labels || steps.meta-override.outputs.labels }}
 
     permissions:
       id-token: write
@@ -41,10 +52,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-
-      - name: Check tag
-        if: inputs.IMAGE_TAG != ''
-        run: echo "::warning::IMAGE_TAG input is deprecated and ignored. Tags are now auto-generated."
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
@@ -64,8 +71,9 @@ jobs:
       - name: Check ECR registry
         run: echo ${{ steps.login-ecr-public.outputs.registry }}/${{ inputs.AWS_ECR_ALIAS }}
 
-      - name: Docker metadata
-        id: meta
+      - name: Docker metadata (auto-generated tags)
+        id: meta-auto
+        if: inputs.IMAGE_TAG == ''
         uses: docker/metadata-action@v5
         with:
           images: ${{ steps.login-ecr-public.outputs.registry }}/${{ inputs.AWS_ECR_ALIAS }}/${{ inputs.IMAGE_NAME }}
@@ -82,7 +90,18 @@ jobs:
             type=ref,event=branch,enable=${{ github.ref_name != 'main' && !startsWith(github.ref, 'refs/tags/') }}
             type=ref,event=tag,enable=${{ startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/v') }}
 
-        # This will cache Docker layers.
+      - name: Docker metadata (explicit tag)
+        id: meta-override
+        if: inputs.IMAGE_TAG != ''
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.login-ecr-public.outputs.registry }}/${{ inputs.AWS_ECR_ALIAS }}/${{ inputs.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ inputs.IMAGE_TAG }}
+
+      # This will cache Docker layers.
         # We could also cache the cache mounts used in the Dockerfile but do not,
         # see https://docs.docker.com/build/ci/github-actions/cache/
       - name: Build and push
@@ -90,8 +109,8 @@ jobs:
         with:
           context: ${{ inputs.BUILD_CONTEXT }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-auto.outputs.tags || steps.meta-override.outputs.tags }}
+          labels: ${{ steps.meta-auto.outputs.labels || steps.meta-override.outputs.labels }}
           build-args: |
             GIT_REF_NAME=${{ github.ref_name }}
             GIT_SHA=${{ github.sha }}


### PR DESCRIPTION
Some repos like [jupyter-images#publish-hub.yaml](https://github.com/EO-DataHub/eodh-jupyter-images/actions/runs/22240943159/workflow) need to use the IMAGE_TAG override.

This PR allows it.

fixes #17