### PR TITLE
update go lint default

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -11,7 +11,7 @@ on:
         description: "GolangCI Lint version"
         required: false
         type: string
-        default: "v2.0.0"
+        default: "v2.1.0"
       coverage-threshold-file:
         description: "Coverage threshold for a single file"
         required: false


### PR DESCRIPTION

`go-build.yaml` was updated in last commits to `golangci/golangci-lint-action v9`, but the default linter version remained `v1.61`.
`golangci-lint-action v9` does not support `golangci-lint v1`, which caused lint jobs to fail with:
`invalid version string 'v1.61', golangci-lint v1 is not supported by golangci-lint-action >= v7`

in other repos PR's like [eodhp-workspaces-services](https://github.com/EO-DataHub/eodhp-workspace-services) :

https://github.com/EO-DataHub/eodhp-workspace-services/actions/runs/22640105255/job/65613534592?pr=39